### PR TITLE
Update API location schema and other changes.

### DIFF
--- a/api/imf-mm-api.(0.8).yaml
+++ b/api/imf-mm-api.(0.8).yaml
@@ -1,0 +1,439 @@
+openapi: 3.0.2
+info:
+  title: IMF Registration API
+  version: '0.8'
+security:
+  - type: [ http, https ]
+servers:
+  - url: https://imf-mm-api.cloud/demo/1
+    description: 'Latest implementation of API from Mr MXF hosted by Amazon Elemental'
+  - url: https://imf-mm-api.cloud/demo/staging
+    description: 'Next release candidate from Mr MXF hosted by Amazon Elemental'
+tags:
+  - name: Asset Registration API
+    description: Register and unregister asset identifiers with locations.
+paths:
+  /assets:
+    post:
+      tags:
+        - Asset Registration API
+      summary: Create an asset registration entry.
+      description: >
+        <p>Create a mapping between one or more asset identifiers, and one or
+        more locations. </p>
+
+        <p>At least one identifier provided must be a digest type (e.g.
+        urn:sha1:...,  urn:c4id:...) that uniquely identifies the asset. </p>
+
+        <p>Systems may require a specific identifier type to act as a primary
+        id. If an identifier type is required but not found then an HTTP 422 Unprocessable 
+        entity error is returned</p>
+
+        <p>The If-None-Match: * header may be used to disallow re-registering an
+        asset.  Without the If-None-Match header subsequent registrations for a
+        given asset will result in the union of identifiers and locations.</p>
+
+        <p>If the submitted registration entry contains identifiers or locations
+        that already exist for different registration entries this will result
+        in a 409 Conflict.</p>
+      parameters:
+        - $ref: '#/components/parameters/ifNoneMatch'
+      requestBody:
+        $ref: '#/components/requestBodies/registerRequestBody'
+      responses:
+        '201':
+          description: >
+            <p>Asset registration created. </p>
+
+            <p>If an asset registration already exists and the If-None-Match
+            header is not specified, the system will match all existing
+            hash-based identifiers before locations are added to the existing
+            registration entry (duplicates are removed).</p>
+          content:
+            application/json:
+              example:
+                message: 'Resource created: ''/assets/urn:sha1:adc83b...e592fc''.'
+                status: 201
+                status_label: Created
+              schema:
+                $ref: '#/components/schemas/responseMessage'
+          headers:
+            Location:
+              description: URL for the newly created asset registration entry.
+              schema:
+                type: string
+        '400':
+          description: The request could not be fulfilled due to the incorrect syntax of the request.
+        '409':
+          description: >
+            Conflict. Identifiers and/or locations already belong to a different
+            registration entries.
+          content:
+            application/json:
+              example:
+                message: 'Ambiguous identifiers.'
+                status: 409
+                status_label: Ambiguous identifiers
+              schema:
+                $ref: '#/components/schemas/responseMessage'
+        '412':
+          description: >
+            Precondition failed. If-None-Match was set and the asset
+            registration entry already exists.
+          content:
+            application/json:
+              example:
+                message: Precondition failed
+                status: 409
+                status_label: Precondition failed
+              schema:
+                $ref: '#/components/schemas/responseMessage'
+        '422':
+          description: >
+            Unprocessable entity. Returned if the system requires a specific 
+            identifier type which was not found.
+          content:
+            application/json:
+              example:
+                message: Primary Id not found
+                status: 422
+                status_label: Unprocessable entity
+              schema:
+                $ref: '#/components/schemas/responseMessage'
+    get:
+      tags:
+        - Asset Registration API
+      summary: Get list of asset registration entries.
+      description: >
+        <b>Get a list of asset registration entries.</b>
+
+        <p>Query parameters 'skip' and 'limit' provide paging support for the
+        results.</p>
+      parameters:
+        - $ref: '#/components/parameters/skipParam'
+        - $ref: '#/components/parameters/limitParam'
+      responses:
+        '200':
+          description: Get List of assets registration entries.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/assetListSchema'
+    parameters:
+      - $ref: '#/components/parameters/acceptHeader'
+  '/assets/{id}':
+    description: |
+      Get, update and delete existing asset registration entries.
+    get:
+      tags:
+        - Asset Registration API
+      summary: Get asset registration information for identifier.
+      description: >
+        Get asset registration information for identifier. If the identifier is
+        ambiguous an HTTP 300 Multiple Choice response is returned with the
+        ability to page through results using skip and limit parameters.
+      parameters:
+        - $ref: '#/components/parameters/assetId'
+        - $ref: '#/components/parameters/skipFor300'
+        - $ref: '#/components/parameters/limitFor300'
+      responses:
+        '200':
+          description: OK. Asset registration information returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/assetInfoSchema'
+          headers:
+            ETag:
+              description: >-
+                Entity Tag. This is any unique value that changes when the
+                record is updated in the database. It is required for PUT
+                operations to prevent race conditions when updating data.
+              schema:
+                $ref: '#/components/schemas/ETagSchema'
+        '300':
+          description: Multiple entries found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/multiChoiceResponse'
+        '404':
+          description: Asset registration entry not found
+    put:
+      tags:
+        - Asset Registration API
+      summary: Update asset registration entry.
+      parameters:
+        - $ref: '#/components/parameters/ifMatch'
+      requestBody:
+        $ref: '#/components/requestBodies/registerRequestBody'
+      responses:
+        '204':
+          description: No Content. Asset registration entry updated.
+          headers:
+            Location:
+              description: URL for the updated asset registration entry.
+              schema:
+                type: string
+        '300':
+          description: Multiple entries found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/multiChoiceResponse'
+        '400':
+          description: The request could not be fulfilled due to the incorrect syntax of the request.
+        '404':
+          description: Asset registration entry not found.
+        '412':
+          description: Precondition failed. ETag did not match for update.
+        '422':
+          description: Unprocessable entity. Returned if the system requires a specific 
+            identifier type which was not found.
+        '428':
+          description: Precondition required. Expecting If-Match header.
+    delete:
+      tags:
+        - Asset Registration API
+      summary: Remove asset registration entry
+      responses:
+        '204':
+          description: No Content. Asset registration entry removed.
+        '300':
+          description: Multiple entries found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/multiChoiceResponse'
+        '404':
+          description: Asset registration entry not found.
+    parameters:
+      - $ref: '#/components/parameters/assetId'
+      - $ref: '#/components/parameters/acceptHeader'
+
+components:
+  parameters:
+    acceptHeader:
+      name: Accept
+      description: Accept header.
+      in: header
+      schema:
+        type: string
+        enum:
+          - application/json
+        example: application/json
+    assetId:
+      name: id
+      description: Asset identifier.
+      required: true
+      in: path
+      schema:
+        $ref: '#/components/schemas/identifierSchema'
+    etag:
+      name: ETag
+      description: Entity Tag
+      in: header
+      schema:
+        $ref: '#/components/schemas/ETagSchema'
+    ifMatch:
+      name: If-Match
+      description: >
+        Used for conditional update of initial asset registration entry. Value
+        should be set to ETag header value of get request.
+      required: true
+      in: header
+      schema:
+        $ref: '#/components/schemas/ETagSchema'
+    ifNoneMatch:
+      name: If-None-Match
+      description: Used for conditional creation of initial asset entry.
+      required: false
+      in: header
+      schema:
+        type: string
+        enum:
+          - '*'
+        example: '*'
+    limitFor300:
+      name: limit
+      description: >
+        Maxiumum number of records to return. This is applicable only if the
+        return result is an HTTP 300 Multiple Choice response.
+      in: query
+      schema:
+        $ref: '#/components/schemas/limitSchema'
+    limitParam:
+      name: limit
+      description: Maxiumum number of records to return.
+      in: query
+      schema:
+        $ref: '#/components/schemas/limitSchema'
+    skipFor300:
+      name: skip
+      description: >
+        Number of records to skip before returning list. This is applicable only
+        if the return result is an HTTP 300 Multiple Choice response.
+      in: query
+      schema:
+        $ref: '#/components/schemas/skipParamSchema'
+    skipParam:
+      name: skip
+      description: Number of records to skip before returning list.
+      in: query
+      schema:
+        $ref: '#/components/schemas/skipParamSchema'
+  headers:
+    Location:
+      description: Location url asset registration entry.
+      schema:
+        type: string
+  requestBodies:
+    registerRequestBody:
+      description: Asset Registration Request Body
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/assetInfoSchema'
+  schemas:
+    assetInfoSchema:
+      title: Asset Info
+      type: object
+      required:
+        - identifiers
+        - locations
+      properties:
+        file_size:
+          type: integer
+        file_type:
+          description: >
+            cc.ft.xml cc.ft.mxf cc.ft.asdcp-mpeg2-ves cc.ft.asdcp-jp2k-j2c
+            cc.ft.asdcp-jp2k-j2c-stereo cc.ft.asdcp-pcm cc.ft.asdcp-text
+            cc.ft.asdcp-aux-data cc.ft.asdcp-atmos cc.ft.cinecanvas cc.ft.png
+            cc.ft.ttf cc.ft.otf cc.ft.cpl cc.ft.pkl cc.ft.map cc.ft.kdm
+            cc.ft.dcdm-text cc.ft.imf-cpl cc.ft.as-02-jp2k-j2c cc.ft.as-02-pcm
+            cc.ft.as-02-text cc.ft.ttml cc.ft.quicktime cc.ft.as-02-prores
+            cc.ft.imf-opl cc.ft.imf-sidecar
+          type: string
+        identifiers:
+          type: array
+          items:
+            $ref: '#/components/schemas/identifierSchema'
+        locations:
+          description: locations is a dictionary whose properties (keys) represent various providerIds under which a list of locations is given.
+          type: object
+          properties:
+            providerId:
+              description: providerId should actually be a patternProperty matching ^.+$ however openapi 3 does not support patternProperty expressions.
+              type: array
+              items:
+                $ref: '#/components/schemas/locationSchema'
+      example:
+        file_size: 456345
+        file_type: cc.ft.cpl
+        identifiers:
+          - 'urn:sha1:0R5e2nhq3NjcIeaUqnDwc3t6XRo='
+          - 'urn:uuid:26e38a18-8e2f-11e9-9bcb-60f81dc89b92'
+          - 'urn:x-short-digest:0R5e2nhq3NjcIeaUqnDwc3t6XRo='
+        locations:
+          localhost:
+            - near_line/vol6/example.mxf
+            - content/pkg42/example.mxf
+          'urn:example.com:providerId2':
+            - content/pkg42/example.mxf
+    assetListSchema:
+      title: Asset List
+      type: object
+      required:
+        - skip
+        - limit
+        - total
+        - results
+      properties:
+        limit:
+          type: integer
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/assetInfoSchema'
+        skip:
+          type: integer
+        total:
+          type: integer
+      example:
+        skip: 0
+        limit: 10
+        total: 2
+        results:
+          - $ref: '#/components/schemas/assetInfoSchema'
+          - $ref: '#/components/schemas/assetInfoSchema'
+    ETagSchema:
+      title: ETag schema
+      type: string
+      example: 7a93350a310f4c1af5c7de4d6e19a9ae
+    identifierSchema:
+      title: Identifier
+      description: >
+        Values to identify asset. Digest string values shall be prefixed (see
+        pattern) to discriminate between possible equivalent alternatives.
+        Multiple identifiers may be associated with a given asset. Hash-based
+        (sha1, c4, etc) values shall be unique to each registration entry.
+      type: string
+      pattern: '^(urn:uuid:|urn:sha1:|urn:c4id:|urn:eidr:|urn:x-).*'
+      example: 'urn:uuid:506...60c'
+    limitAllSchema:
+      description: >
+        A value of ALL for limit will result in the maximum number of entries
+        allowed by the system (max limit)
+      type: string
+      enum:
+        - ALL
+    limitSchema:
+      oneOf:
+        - $ref: '#/components/schemas/limitValueSchema'
+        - $ref: '#/components/schemas/limitAllSchema'
+    limitValueSchema:
+      description: >
+        A limit can be an integer value indicating the maximum of entries to
+        return in a query. A limit value set greater than the system's internal
+        max limit value will be clamped to the max limit value number.
+      type: integer
+      default: 20
+      example: 20
+    locationSchema:
+      type: string
+    multiChoiceResponse:
+      title: Multi-choice Response
+      type: object
+      properties:
+        limit:
+          type: integer
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/assetInfoSchema'
+        skip:
+          type: integer
+        total:
+          type: integer
+      example:
+        skip: 0
+        limit: 10
+        total: 2
+        results:
+          - $ref: '#/components/schemas/assetInfoSchema'
+          - $ref: '#/components/schemas/assetInfoSchema'
+    responseMessage:
+      title: Response Message
+      type: object
+      properties:
+        message:
+          type: string
+        status:
+          description: HTTP status code.
+          type: integer
+        status_label:
+          type: string
+    skipParamSchema:
+      type: integer
+      default: 0


### PR DESCRIPTION
    - use 400 error for bad syntax errors
    - introduce 422 error when system requires an identifier of
      a particular type but isn't found
    - remove XML references
    - make getAssetInfo example consistent with other examples.
    - rename 'etag' to 'ETag' to be somewhat consistent with
      header names (e.g. Accept instead of accept)
    - add markup in some descriptions for better display in swagger editor.
    - changed file_type enums to a simple string (with previous
      enums moved to the description) in order to hardcoding possible values.

    Note: when describing the provideIds within the location
    schema the ideal was to use JSON schema patternProperties
    but that is not supported in openapi version 3. The intent
    is to show that provider ids can be any string.